### PR TITLE
keep all-land blocks when coupling to GEOS-ESM

### DIFF
--- a/cicecore/cicedyn/infrastructure/ice_domain.F90
+++ b/cicecore/cicedyn/infrastructure/ice_domain.F90
@@ -563,7 +563,7 @@
          ! use processor_shape = 'square-pop' and distribution_wght = 'block'
          ! to make CICE and POP decompositions/distributions identical.
 
-#ifdef CICE_IN_NEMO
+#if defined(CICE_IN_NEMO) || defined(GEOSCOUPLED)
          ! Keep all blocks even the ones only containing land points
          if (distribution_wght == 'block') nocn(n) = nx_block*ny_block
 #else


### PR DESCRIPTION
This PR keeps all-land blocks on all processors. ```CICE6``` **by default** will not allocate blocks on processors if all grid cells are land. This caused some problems in the history outputs in the 1440x1080 resolution. This PR reuses the same code to keep these blocks as in ```CICE_IN_NEMO``` mode.   